### PR TITLE
Fix expansions in included file contents

### DIFF
--- a/git-playback.sh
+++ b/git-playback.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ef
 
 if [ $# -eq 0 ]; then
   set -- -h


### PR DESCRIPTION
Fixes broken css includes by disabling filename expansions. 
For example in my case:
`*/` inside style css gets expanded to the file in current folder `__pycache__/` thus generating invalid style tag content.
